### PR TITLE
Don't build ncit-graph or targets that depend on it.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -16,7 +16,7 @@ RELEASEPREFIX=$(PREFIX)/releases/$(DATE)
 
 
 .PHONY: all
-all: $(NCIT) ncit.obo ncit-graph.jnl ncit-bridge-to-cl.owl ncit-bridge-to-uberon.owl ncit-plus.owl ncit-negations.owl ncit-plus-negations.owl ncit-benign-malignant.ttl neoplasm-hierarchy-report.txt neoplasm-core.owl ncit-oncotree.ttl ncit-oncotree.obo
+all: $(NCIT) ncit.obo ncit-bridge-to-cl.owl ncit-bridge-to-uberon.owl ncit-plus.owl ncit-negations.owl ncit-plus-negations.owl neoplasm-hierarchy-report.txt neoplasm-core.owl ncit-oncotree.ttl ncit-oncotree.obo
 
 $(SRC):
 	curl -L -O https://evs.nci.nih.gov/ftp1/rdf/Thesaurus.owl


### PR DESCRIPTION
@matentzn I removed building of the ncit-graph file. I don't think this is necessary at this point. This should resolve your problem downloading the reactome file.